### PR TITLE
Add Ubuntu 16.04 tag to vpgrp/ansible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,16 @@ build-debian-9:
   script:
     - docker build --rm debian/9
 
+build-ubuntu-1604:
+  stage: docker
+  image: docker:latest
+  services:
+    - docker:dind
+  variables:
+    DOCKER_DRIVER: overlay
+  script:
+    - docker build --rm ubuntu/16.04
+
 build-centos-6:
   stage: docker
   image: docker:latest

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Docker images of Ansible.
 
 Supported tags and respective Dockerfile links.
 
-- debian-9, latest ([debian/9/Dockerfile](debian/9/Dockerfile))
+- debian-9, latest ([debian/9/Dockerfile](debian/9/Dockerfile)), ubuntu-1604 ([ubuntu/16.04/Dockerfile](ubuntu/16.04/Dockerfile))
 
 ## Usage
 

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright (c) 2018 Vente-Privée
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM vpgrp/ubuntu:16.04 as ansible
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    TZ="Europe/Amsterdam"
+
+RUN apt-get update  -qq && \
+    apt-get upgrade -qq -y && \
+    apt-get install -qq -y \
+      build-essential \
+      libffi-dev \
+      libssl-dev \
+      python-dev \
+      python-pip \
+      python-setuptools \
+      python-wheel && \
+    apt-clean && \
+    pip install --upgrade \
+      ansible \
+      cryptography
+
+FROM vpgrp/ubuntu:16.04
+
+COPY --from=ansible /usr/local /usr/local
+
+RUN apt-get update  -qq && \
+    apt-get upgrade -qq -y && \
+    apt-get install -qq -y \
+      iproute2 \
+      openssh-client \
+      python \
+      python-netaddr \
+      ruby \
+      ruby-dev \
+      rubygems \
+      sudo \
+      systemd && \
+    apt-clean
+
+WORKDIR /etc/ansible
+
+RUN /bin/echo -e \
+      '[local]\nlocalhost ansible_connection=local' > \
+      /etc/ansible/hosts
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+HEALTHCHECK NONE
+# EOF


### PR DESCRIPTION
# Summary
- Adding `ubuntu-1604` tag to `vpgrp/ansible` so that it could be used to test ansible roles with ubuntu 16.04 (xenial)